### PR TITLE
fixed TypeError in compile_messages() due to Django 1.6 change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ def compile_translations():
     curdir = os.getcwdu()
     os.chdir(os.path.join(os.path.dirname(__file__), 'invitation'))
     try:
-        compile_messages(stderr=sys.stderr)
+        # Django >= 1.6 uses 'stdout' as method argument, Django <= 1.5 uses 'stderr'
+        # support both by omitting the argument name:
+        compile_messages(sys.stderr)
     except TypeError:
         # compile_messages doesn't accept stderr parameter prior to 1.2.4
         compile_messages()


### PR DESCRIPTION
This allows installation when using Django 1.6, and retains compatibility with earlier versions.
